### PR TITLE
Version should be a string rather than json.Number

### DIFF
--- a/shodan/host.go
+++ b/shodan/host.go
@@ -1,9 +1,5 @@
 package shodan
 
-import (
-	"encoding/json"
-)
-
 const (
 	hostPath             = "/shodan/host"
 	hostCountPath        = "/shodan/host/count"
@@ -35,7 +31,7 @@ type HostLocation struct {
 type HostData struct {
 	Product      string                 `json:"product"`
 	Hostnames    []string               `json:"hostnames"`
-	Version      json.Number            `json:"version"`
+	Version      string                 `json:"version"`
 	Title        string                 `json:"title"`
 	IPLong       int                    `json:"ip"`
 	IP           string                 `json:"ip_str"`

--- a/shodan/stubs/host/version.json
+++ b/shodan/stubs/host/version.json
@@ -9,7 +9,7 @@
       },
       "product": "www.solugames.com",
       "hash": -1224263288,
-      "version": 47,
+      "version": "47",
       "ip": 3187713176,
       "isp": "Level 3 Communications",
       "os": null,


### PR DESCRIPTION
For certain version 'strings' it might work out to use the type
json.Number, but this isn't always the case. The best example is a
version with a patch level, like 1.12.1 (as nginx might report it). This
value isn't allowed to be serialized back into JSON as it isn't a
number, it's a string.

Long story short, the Version member should be a string rather than a
number.