### PR TITLE
Corrected import

### DIFF
--- a/shodan/shodan.go
+++ b/shodan/shodan.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 
 	"github.com/google/go-querystring/query"
-	"github.com/moul/http2curl"
+	"moul.io/http2curl"
 )
 
 const (


### PR DESCRIPTION
I can't compile it neither on my Mac nor on my Debian box if it's not "moul.io/http2curl". Gives me 'expects import "moul.io/http2curl"'.